### PR TITLE
fix typos, mistakes in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Module Utils for Bitfocus Companion Modules
-This project provides utility functions to simplify some of the complex tasks that is common throughout many Companion modules, such as the generation of graphics in Feedbacks.
+This project provides utility functions to simplify some of the complex tasks common throughout many Companion modules, such as the generation of graphics in Feedbacks.
 
 ## Features
 * Create simple button graphics for use in Bitfocus Companion modules

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -1,5 +1,5 @@
 # Graphics
-This module currently has the following methods to help draw graphics in an image buffer. Using `stackImage` it is also possible stack multiple of these image buffers to create more complex graphics, some of which are already made available as [Presets](./presets.md)
+This module currently has the following methods to help draw graphics in an image buffer. Using `stackImage` it is also possible to stack multiple of these image buffers to create more complex graphics, some of which are already made available as [Presets](./presets.md)
 
 [Bar](#bar)  
 [Border](#border)  

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -147,7 +147,7 @@ Generates an image buffer of a circle at a specified radius. Width and Height ar
 | ----- | ----- |
 | `opacity` | 0 - 255 |
 
-### Exmaple
+### Example
 ```javascript
 const { graphics } = require('companion-module-utilz')
 

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -1,5 +1,5 @@
 # Graphics
-This module currently has the following methods to help draw graphics in an image buffer. Using `stackImage` it is also possible stack multiple of these image buffers to create more complext graphics, some of which are already made available as a [Presets](./presets.md)
+This module currently has the following methods to help draw graphics in an image buffer. Using `stackImage` it is also possible stack multiple of these image buffers to create more complex graphics, some of which are already made available as [Presets](./presets.md)
 
 [Bar](#bar)  
 [Border](#border)  
@@ -15,7 +15,7 @@ This module currently has the following methods to help draw graphics in an imag
 ---
 ## Bar
 ### Description
-Generates an imagebuffer of a bar representing a value from 0 to 100. The bar can be colored in different sections by providing multiple `colors`, where the total size equals 100. This for example allows for both simple progress bars to more complex volume meters with different colored sections for different dB levels.
+Generates an imagebuffer of a bar representing a value from 0 to 100. The bar can be colored in different sections by providing multiple `colors`, where the total size equals 100. This allows for simple progress bars and more complex volume meters with different colored sections for different dB levels.
 
 ![](./images/barExample.png)  
 
@@ -79,7 +79,7 @@ micVolumeFeedback: {
 ---
 ## Border
 ### Description
-Generates a border around the outter edge of the image, defaulting to all sides but can be limit to a specifc side.
+Generates a border around the outter edge of the image, defaulting to all sides but can be limited to a specifc side.
 
 ![](./images/borderExample.png) 
 
@@ -153,10 +153,10 @@ const { graphics } = require('companion-module-utilz')
 
 ...
 
-exampleBorderFeedback: {
+exampleCircleFeedback: {
   type: 'advanced',
-  name: 'Border example',
-  description: 'Checks a value, and if true returns a border around the edge of the button',
+  name: 'Circle example',
+  description: 'Checks a value, and if true returns a red circle icon',
   options: [
     ...
   ],
@@ -173,7 +173,7 @@ exampleBorderFeedback: {
       const circleIcon = graphics.icon({
           width: feedback.image.width,
           height: feedback.image.height,
-          custom: circle1
+          custom: circle,
           type: 'custom',
           customHeight: 16,
           customWidth: 16,
@@ -290,11 +290,11 @@ micStateFeedback: {
     }
 
     if (mic.muted) {
-      options.type === 'mic3'
+      options.type = 'mic3'
     } else if (mic.active) {
-      options.type === 'mic5'
+      options.type = 'mic5'
     } else {
-      options.type === 'mic1'
+      options.type = 'mic1'
     }
 
     return {

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -116,7 +116,7 @@ exampleBorderFeedback: {
         width: feedback.image.width,
         height: feedback.image.height,
         color: combineRgb(255, 0, 0),
-        size: 5.
+        size: 5,
         opacity: 255,
         type: 'border'
       }
@@ -229,7 +229,7 @@ exampleCornerFeedback: {
         width: feedback.image.width,
         height: feedback.image.height,
         color: combineRgb(255, 0, 0),
-        size: 5.
+        size: 5,
         location: 'topLeft',
         opacity: 255
       }
@@ -352,7 +352,7 @@ exampleRectFeedback: {
         rectWidth: 60,
         rectHeight: 26,
         strokeWidth: 4,
-        opacity: 255
+        opacity: 255,
         fillColor: combineRgb(255, 0, 0),
         fillOpacity: 128,
         offsetX: 6,


### PR DESCRIPTION
Thanks for the useful library. I've been working through some of the graphics functions, and thought Id tidy up some typos and what appear to be mistakes in the example code.